### PR TITLE
Trim trailing whitespace from `wc -c` on macOS

### DIFF
--- a/README.sh
+++ b/README.sh
@@ -14,7 +14,7 @@ Awfice is a collection of tiny office suite apps:
 * this project is only a half-joke, I actually use a few Awfice apps as quick scratchpads.
 * the only way to save your job is to save a HTML or send it to the printer/print to PDF.
 
-## Text editor - $(wc -c < edit.html) bytes!
+## Text editor - $(wc -c < edit.html | tr -d ' ') bytes!
 
 A simple rich text editor. Type whatever you want, it won't be saved anywhere, but it might be convenient for quick throwaway notes. You should be able to use Ctrl+B and Ctrl+I to mark text selection as bold or italic. Undo/redo should work as well. You can also copy/paste text and images from other sources.
 
@@ -26,7 +26,7 @@ data:text/html,$(cat edit.html)
 
 [Try it!](https://htmlpreview.github.io/?https://github.com/zserge/awfice/blob/main/edit.html)
 
-## Spreadsheet - $(wc -c < calc.html) bytes!
+## Spreadsheet - $(wc -c < calc.html | tr -d ' ') bytes!
 
 A very basic spreadsheet with math formulas. It has 100 rows and 26 columns (A..Z). If the value in the cell starts with an "=" = it is evaluated as a formula. You may refer to other cell values, i.e. "=(A10+A11)/A12". Under the hood it uses eval(), so be careful.
 
@@ -38,7 +38,7 @@ data:text/html,$(cat calc.html)
 
 [Try it!](https://htmlpreview.github.io/?https://github.com/zserge/awfice/blob/main/calc.html)
 
-## Drawing app - $(wc -c < draw.html) bytes!
+## Drawing app - $(wc -c < draw.html | tr -d ' ') bytes!
 
 Nothing simpler than drawing on a blank canvas with mouse. Works with touch screens as well. To save your results... well, do a screenshot maybe...
 
@@ -50,7 +50,7 @@ data:text/html,$(cat draw.html)
 
 [Try it!](https://htmlpreview.github.io/?https://github.com/zserge/awfice/blob/main/draw.html)
 
-## Presentation maker - $(wc -c < beam.html) bytes!
+## Presentation maker - $(wc -c < beam.html | tr -d ' ') bytes!
 
 Just a variant of a rich text editor with some hotkeys. There are 50 blank slides for you (I hope you don't need to bore your audience with more slides). Each slide is a rich text editor, but there are some hotkeys to make styling better:
 


### PR DESCRIPTION
The command `wc -c` on macOS pads the output with spaces.

When piping through `tr -d ' '`, these padding spaces will be removed.  
On Linux (tested Debian Strech) it's a no-op.
